### PR TITLE
Add OAS v3.2.0 representation. Add OAS 3.2.0 improvements to the Tag object.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.8-focal
-          - swift:5.8-jammy
-          - swift:5.9-focal
-          - swift:5.9-jammy
           - swift:5.10-focal
           - swift:5.10-jammy
           - swift:6.0-focal

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
           - swift:6.1-focal
           - swift:6.1-jammy
           - swift:6.1-noble
+          - swift:6.2-jammy
+          - swift:6.2-noble
           - swiftlang/swift:nightly-focal
           - swiftlang/swift:nightly-jammy
     container: ${{ matrix.image }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level) [![Swift 5.8+](http://img.shields.io/badge/Swift-5.8+-blue.svg)](https://swift.org)
+[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#sandbox-level) [![Swift 5.10+](http://img.shields.io/badge/Swift-5.10+-blue.svg)](https://swift.org)
 
 [![MIT license](http://img.shields.io/badge/license-MIT-lightgrey.svg)](http://opensource.org/licenses/MIT) ![Tests](https://github.com/mattpolzin/OpenAPIKit/workflows/Tests/badge.svg)
 

--- a/Sources/OpenAPIKit/OpenAPIConditionalWarnings.swift
+++ b/Sources/OpenAPIKit/OpenAPIConditionalWarnings.swift
@@ -47,7 +47,7 @@ internal struct DocumentVersionCondition: Sendable, Condition {
 internal extension OpenAPI.Document {
     struct ConditionalWarnings {
         static func version(lessThan version: OpenAPI.Document.Version, doesNotSupport subject: String) -> (any Condition, OpenAPI.Warning) {
-            let warning = OpenAPI.Warning.message("\(subject) is only supported for OpenAPI document versions \(version.rawValue) and later.")
+            let warning = OpenAPI.Warning.message("\(subject) is only supported for OpenAPI document versions \(version.rawValue) and later")
 
             return (DocumentVersionCondition(version: version, comparator: .lessThan), warning)
         }

--- a/Sources/OpenAPIKit/OpenAPIConditionalWarnings.swift
+++ b/Sources/OpenAPIKit/OpenAPIConditionalWarnings.swift
@@ -1,0 +1,55 @@
+public protocol Condition: Equatable, Sendable {
+    /// Given an entire OpenAPI Document, determine the applicability of the
+    /// condition.
+    func applies(to: OpenAPI.Document) -> Bool
+}
+
+public protocol HasConditionalWarnings {
+    /// Warnings that only apply if the paired condition is met.
+    ///
+    /// Among other things, this allows OpenAPIKit to generate a warning in
+    /// some nested type that only applies if the OpenAPI Standards version of
+    /// the document is less than a certain version.
+    var conditionalWarnings: [(any Condition, OpenAPI.Warning)] { get }
+}
+
+extension HasConditionalWarnings {
+    public func applicableConditionalWarnings(for subject: OpenAPI.Document) -> [OpenAPI.Warning] {
+        conditionalWarnings.compactMap { (condition, warning) in
+            guard condition.applies(to: subject) else { return nil }
+
+            return warning
+        }
+    }
+}
+
+internal struct DocumentVersionCondition: Sendable, Condition {
+    enum Comparator: Sendable {
+        case lessThan
+        case equal
+        case greaterThan
+    }
+
+    let version: OpenAPI.Document.Version
+    let comparator: Comparator
+
+    func applies(to document: OpenAPI.Document) -> Bool {
+        switch comparator {
+        case .lessThan: document.openAPIVersion < version
+
+        case .equal: document.openAPIVersion == version
+
+        case .greaterThan: document.openAPIVersion > version
+        }
+    }
+}
+
+internal extension OpenAPI.Document {
+    struct ConditionalWarnings {
+        static func version(lessThan version: OpenAPI.Document.Version, doesNotSupport subject: String) -> (any Condition, OpenAPI.Warning) {
+            let warning = OpenAPI.Warning.message("\(subject) is only supported for OpenAPI document versions \(version.rawValue) and later.")
+
+            return (DocumentVersionCondition(version: version, comparator: .lessThan), warning)
+        }
+    }
+}

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -1042,7 +1042,7 @@ extension JSONSchema.CoreContext: Decodable {
                 .underlyingError(
                       GenericError(
                           subjectName: "OpenAPI Schema",
-                          details: "Found 'nullable' property. This property is not supported by OpenAPI v3.1.x. OpenAPIKit has translated it into 'type: [\"null\", ...]'.",
+                          details: "Found 'nullable' property. This property is not supported by OpenAPI v3.1.x. OpenAPIKit has translated it into 'type: [\"null\", ...]'",
                           codingPath: container.codingPath
                       )
                   )

--- a/Sources/OpenAPIKit/Validator/Validation.swift
+++ b/Sources/OpenAPIKit/Validator/Validation.swift
@@ -128,10 +128,12 @@ public struct ValidationError: Swift.Error, CustomStringConvertible, PathContext
     public var localizedDescription: String { description }
 
     public var description: String {
+        let reasonStr: any StringProtocol =
+            reason.last == "." ? reason.dropLast() : reason
         guard !codingPath.isEmpty else {
-            return "\(reason) at root of document"
+            return "\(reasonStr) at root of document"
         }
-        return "\(reason) at path: \(codingPath.stringValue)"
+        return "\(reasonStr) at path: \(codingPath.stringValue)"
     }
 }
 

--- a/Sources/OpenAPIKit/Validator/Validator.swift
+++ b/Sources/OpenAPIKit/Validator/Validator.swift
@@ -545,9 +545,15 @@ extension _Validator: SingleValueEncodingContainer {
 
     fileprivate func collectWarnings(from value: Encodable, atKey key: CodingKey? = nil) {
         let pathTail = key.map { [$0] } ?? []
+        var localWarnings = [Warning]()
         if let warnable = value as? HasWarnings {
-            warnings += warnable.warnings.map(contextualize(at: codingPath + pathTail))
+            localWarnings += warnable.warnings
         }
+        if let conditionalWarnable = value as? HasConditionalWarnings {
+            localWarnings += conditionalWarnable.applicableConditionalWarnings(for: document)
+        }
+
+        warnings += localWarnings.map(contextualize(at: codingPath + pathTail))
     }
 }
 

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -430,8 +430,10 @@ extension OpenAPIKit30.OpenAPI.Tag: To31 {
     fileprivate func to31() -> OpenAPIKit.OpenAPI.Tag {
         OpenAPIKit.OpenAPI.Tag(
             name: name,
+            summary: nil,
             description: description,
             externalDocs: externalDocs?.to31(),
+            parent: nil,
             vendorExtensions: vendorExtensions
         )
     }

--- a/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/OpenAPIWarning.swift
+++ b/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/OpenAPIWarning.swift
@@ -65,5 +65,6 @@ extension Warning: CustomStringConvertible {
 }
 
 public protocol HasWarnings {
+    /// Warnings generated while decoding an OpenAPI type.
     var warnings: [Warning] { get }
 }

--- a/Tests/OpenAPIKitErrorReportingTests/SchemaErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/SchemaErrorTests.swift
@@ -76,7 +76,7 @@ final class SchemaErrorTests: XCTestCase {
 
             XCTAssertEqual(openAPIError.localizedDescription,
             """
-            Problem encountered when parsing `OpenAPI Schema`: Found 'nullable' property. This property is not supported by OpenAPI v3.1.x. OpenAPIKit has translated it into 'type: ["null", ...]'.. at path: .paths['/hello/world'].get.responses.200.content['application/json'].schema
+            Problem encountered when parsing `OpenAPI Schema`: Found 'nullable' property. This property is not supported by OpenAPI v3.1.x. OpenAPIKit has translated it into 'type: ["null", ...]' at path: .paths['/hello/world'].get.responses.200.content['application/json'].schema
             """)
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -54,18 +54,39 @@ final class DocumentTests: XCTestCase {
         let t4 = OpenAPI.Document.Version.v3_1_x(x: 8)
         XCTAssertEqual(t4.rawValue, "3.1.8")
 
-        let t5 = OpenAPI.Document.Version(rawValue: "3.1.0")
-        XCTAssertEqual(t5, .v3_1_0)
+        let t5 = OpenAPI.Document.Version.v3_2_0
+        XCTAssertEqual(t5.rawValue, "3.2.0")
 
-        let t6 = OpenAPI.Document.Version(rawValue: "3.1.1")
-        XCTAssertEqual(t6, .v3_1_1)
+        let t6 = OpenAPI.Document.Version(rawValue: "3.1.0")
+        XCTAssertEqual(t6, .v3_1_0)
 
-        let t7 = OpenAPI.Document.Version(rawValue: "3.1.2")
-        XCTAssertEqual(t7, .v3_1_2)
+        let t7 = OpenAPI.Document.Version(rawValue: "3.1.1")
+        XCTAssertEqual(t7, .v3_1_1)
+
+        let t8 = OpenAPI.Document.Version(rawValue: "3.1.2")
+        XCTAssertEqual(t8, .v3_1_2)
 
         // not a known version:
-        let t8 = OpenAPI.Document.Version(rawValue: "3.1.8")
-        XCTAssertNil(t8)
+        let t9 = OpenAPI.Document.Version(rawValue: "3.1.8")
+        XCTAssertNil(t9)
+
+        let t10 = OpenAPI.Document.Version(rawValue: "3.2.8")
+        XCTAssertNil(t10)
+    }
+
+    func test_compareOASVersions() {
+        let versions: [OpenAPI.Document.Version] = [
+          .v3_1_0,
+          .v3_1_1,
+          .v3_1_2,
+          .v3_2_0
+        ]
+
+        for v1Idx in 0...(versions.count - 2) {
+            for v2Idx in (v1Idx + 1)...(versions.count - 1) {
+                XCTAssert(versions[v1Idx] < versions[v2Idx])
+            }
+        }
     }
 
     func test_getRoutes() {

--- a/Tests/OpenAPIKitTests/TagTests.swift
+++ b/Tests/OpenAPIKitTests/TagTests.swift
@@ -45,6 +45,12 @@ final class TagTests: XCTestCase {
             parent: "otherTag"
         )
         XCTAssertEqual(t5.parent, "otherTag")
+
+        let t6 = OpenAPI.Tag(
+            name: "hello",
+            kind: .nav
+        )
+        XCTAssertEqual(t6.kind, .nav)
     }
 }
 
@@ -177,6 +183,39 @@ extension TagTests {
         XCTAssertEqual(tag.conditionalWarnings.count, 1)
     }
 
+    func test_nameAndKind_encode() throws {
+        let tag = OpenAPI.Tag(
+            name: "hello",
+            kind: .badge
+        )
+        let encodedTag = try orderUnstableTestStringFromEncoding(of: tag)
+
+        assertJSONEquivalent(
+            encodedTag,
+            """
+            {
+              "kind" : "badge",
+              "name" : "hello"
+            }
+            """
+        )
+    }
+
+    func test_nameAndKind_decode() throws {
+        let tagData =
+        """
+        {
+            "name": "hello",
+            "kind": "audience"
+        }
+        """.data(using: .utf8)!
+
+        let tag = try orderUnstableDecode(OpenAPI.Tag.self, from: tagData)
+
+        XCTAssertEqual(tag, OpenAPI.Tag(name: "hello", kind: .audience))
+        XCTAssertEqual(tag.conditionalWarnings.count, 1)
+    }
+
     func test_allFields_encode() throws {
         let tag = OpenAPI.Tag(
             name: "hello",
@@ -186,6 +225,7 @@ extension TagTests {
                 url: URL(string: "http://google.com")!
             ),
             parent: "otherTag",
+            kind: "mytag",
             vendorExtensions: ["x-specialFeature": false]
         )
         let encodedTag = try orderUnstableTestStringFromEncoding(of: tag)
@@ -198,6 +238,7 @@ extension TagTests {
               "externalDocs" : {
                 "url" : "http:\\/\\/google.com"
               },
+              "kind" : "mytag",
               "name" : "hello",
               "parent" : "otherTag",
               "summary" : "sum",
@@ -218,6 +259,7 @@ extension TagTests {
                 "url": "http://google.com"
             },
             "parent": "otherTag",
+            "kind": "mytag",
             "x-specialFeature" : false
         }
         """.data(using: .utf8)!
@@ -232,9 +274,10 @@ extension TagTests {
                 description: "world",
                 externalDocs: .init(url: URL(string: "http://google.com")!),
                 parent: "otherTag",
+                kind: "mytag",
                 vendorExtensions: ["x-specialFeature": false]
             )
         )
-        XCTAssertEqual(tag.conditionalWarnings.count, 2)
+        XCTAssertEqual(tag.conditionalWarnings.count, 3)
     }
 }

--- a/Tests/OpenAPIKitTests/TagTests.swift
+++ b/Tests/OpenAPIKitTests/TagTests.swift
@@ -39,6 +39,12 @@ final class TagTests: XCTestCase {
             .overriddenNonNil(description: nil) // no effect
         XCTAssertEqual(t4.summary, "cool")
         XCTAssertEqual(t4.description, "new")
+
+        let t5 = OpenAPI.Tag(
+            name: "hello",
+            parent: "otherTag"
+        )
+        XCTAssertEqual(t5.parent, "otherTag")
     }
 }
 
@@ -138,6 +144,39 @@ extension TagTests {
         XCTAssertEqual(tag.conditionalWarnings.count, 0)
     }
 
+    func test_nameAndParent_encode() throws {
+        let tag = OpenAPI.Tag(
+            name: "hello",
+            parent: "otherTag"
+        )
+        let encodedTag = try orderUnstableTestStringFromEncoding(of: tag)
+
+        assertJSONEquivalent(
+            encodedTag,
+            """
+            {
+              "name" : "hello",
+              "parent" : "otherTag"
+            }
+            """
+        )
+    }
+
+    func test_nameAndParent_decode() throws {
+        let tagData =
+        """
+        {
+            "name": "hello",
+            "parent": "otherTag"
+        }
+        """.data(using: .utf8)!
+
+        let tag = try orderUnstableDecode(OpenAPI.Tag.self, from: tagData)
+
+        XCTAssertEqual(tag, OpenAPI.Tag(name: "hello", parent: "otherTag"))
+        XCTAssertEqual(tag.conditionalWarnings.count, 1)
+    }
+
     func test_allFields_encode() throws {
         let tag = OpenAPI.Tag(
             name: "hello",
@@ -146,6 +185,7 @@ extension TagTests {
             externalDocs: .init(
                 url: URL(string: "http://google.com")!
             ),
+            parent: "otherTag",
             vendorExtensions: ["x-specialFeature": false]
         )
         let encodedTag = try orderUnstableTestStringFromEncoding(of: tag)
@@ -159,6 +199,7 @@ extension TagTests {
                 "url" : "http:\\/\\/google.com"
               },
               "name" : "hello",
+              "parent" : "otherTag",
               "summary" : "sum",
               "x-specialFeature" : false
             }
@@ -176,6 +217,7 @@ extension TagTests {
             "externalDocs": {
                 "url": "http://google.com"
             },
+            "parent": "otherTag",
             "x-specialFeature" : false
         }
         """.data(using: .utf8)!
@@ -189,9 +231,10 @@ extension TagTests {
                 summary: "sum",
                 description: "world",
                 externalDocs: .init(url: URL(string: "http://google.com")!),
+                parent: "otherTag",
                 vendorExtensions: ["x-specialFeature": false]
             )
         )
-        XCTAssertEqual(tag.conditionalWarnings.count, 1)
+        XCTAssertEqual(tag.conditionalWarnings.count, 2)
     }
 }

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -1484,7 +1484,7 @@ final class ValidatorTests: XCTestCase {
             XCTAssertEqual(errors?.values.count, 1)
             XCTAssertEqual(
                 errors?.localizedDescription,
-                "Problem encountered when parsing ``: \'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'. at path: .paths[\'/test\'].get.responses.200.content"
+                "Problem encountered when parsing ``: \'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\' at path: .paths[\'/test\'].get.responses.200.content"
             )
             XCTAssertEqual(errors?.values.first?.codingPathString, ".paths[\'/test\'].get.responses.200.content")
         }
@@ -1503,7 +1503,7 @@ final class ValidatorTests: XCTestCase {
 
         XCTAssertEqual(
             doc.tags?.first?.applicableConditionalWarnings(for: doc).first?.localizedDescription,
-            "The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later."
+            "The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later"
         )
 
         let warnings = try doc.validate(strict: false)
@@ -1511,7 +1511,7 @@ final class ValidatorTests: XCTestCase {
         XCTAssertEqual(warnings.count, 1)
         XCTAssertEqual(
             warnings.first?.localizedDescription,
-            "Problem encountered when parsing ``: The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later.."
+            "Problem encountered when parsing ``: The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later."
         )
         XCTAssertEqual(warnings.first?.codingPathString, ".tags[0]")
 
@@ -1535,7 +1535,7 @@ final class ValidatorTests: XCTestCase {
 
         XCTAssertEqual(
             doc.tags?.first?.applicableConditionalWarnings(for: doc).first?.localizedDescription,
-            "The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later."
+            "The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later"
         )
 
         XCTAssertThrowsError(try doc.validate(strict: true)) { error in
@@ -1543,7 +1543,7 @@ final class ValidatorTests: XCTestCase {
             XCTAssertEqual(errors?.values.count, 1)
             XCTAssertEqual(
                 errors?.localizedDescription,
-                "Problem encountered when parsing ``: The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later.. at path: .tags[0]"
+                "Problem encountered when parsing ``: The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later at path: .tags[0]"
             )
             XCTAssertEqual(errors?.values.first?.codingPathString, ".tags[0]")
         }

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -1489,4 +1489,63 @@ final class ValidatorTests: XCTestCase {
             XCTAssertEqual(errors?.values.first?.codingPathString, ".paths[\'/test\'].get.responses.200.content")
         }
     }
+
+    func test_collectsConditionalTagWarningNotStrict() throws {
+        let docData = """
+        {
+          "info": {"title": "test", "version": "1.0"},
+          "openapi": "3.1.0",
+          "tags": [ {"name": "hi", "summary": "sum"} ]
+        }
+        """.data(using: .utf8)!
+
+        let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
+
+        XCTAssertEqual(
+            doc.tags?.first?.applicableConditionalWarnings(for: doc).first?.localizedDescription,
+            "The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later."
+        )
+
+        let warnings = try doc.validate(strict: false)
+
+        XCTAssertEqual(warnings.count, 1)
+        XCTAssertEqual(
+            warnings.first?.localizedDescription,
+            "Problem encountered when parsing ``: The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later.."
+        )
+        XCTAssertEqual(warnings.first?.codingPathString, ".tags[0]")
+
+        // now test that the warning does not apply for v3.2.0 and above
+        var doc2 = doc
+        doc2.openAPIVersion = .v3_2_0
+
+        try XCTAssertEqual(doc2.validate(strict: false).count, 0)
+    }
+
+    func test_collectsConditionalTagWarningStrict() throws {
+        let docData = """
+        {
+          "info": {"title": "test", "version": "1.0"},
+          "openapi": "3.1.0",
+          "tags": [ {"name": "hi", "summary": "sum"} ]
+        }
+        """.data(using: .utf8)!
+
+        let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
+
+        XCTAssertEqual(
+            doc.tags?.first?.applicableConditionalWarnings(for: doc).first?.localizedDescription,
+            "The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later."
+        )
+
+        XCTAssertThrowsError(try doc.validate(strict: true)) { error in
+            let errors = error as? ValidationErrorCollection
+            XCTAssertEqual(errors?.values.count, 1)
+            XCTAssertEqual(
+                errors?.localizedDescription,
+                "Problem encountered when parsing ``: The Tag summary field is only supported for OpenAPI document versions 3.2.0 and later.. at path: .tags[0]"
+            )
+            XCTAssertEqual(errors?.values.first?.codingPathString, ".tags[0]")
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/425.

## Breaking
- The `OpenAPI.Version` enumeration gains new cases.
- Some error message strings have changed subtly for more natural language readability. This will only impact you if OpenAPIKit errors are matched on by string value (likely in a test suite if anywhere).
- Drop support for Swift versions prior to 5.10. 
