### PR TITLE
Support and prefer new official yaml media type

### DIFF
--- a/Sources/OpenAPIKitCore/Shared/ContentType.swift
+++ b/Sources/OpenAPIKitCore/Shared/ContentType.swift
@@ -305,7 +305,7 @@ extension Shared.ContentType.Builtin: RawRepresentable {
         case .woff: return "font/woff"
         case .woff2: return "font/woff2"
         case .xml: return "application/xml"
-        case .yaml: return "application/x-yaml"
+        case .yaml: return "application/yaml"
         case .zip: return "application/zip"
 
         case .anyApplication: return "application/*"
@@ -359,6 +359,7 @@ extension Shared.ContentType.Builtin: RawRepresentable {
         case "font/woff2": self = .woff2
         case "application/xml": self = .xml
         case "application/x-yaml": self = .yaml
+        case "application/yaml": self = .yaml
         case "application/zip": self = .zip
 
         case "application/*": self = .anyApplication

--- a/Tests/OpenAPIKitCoreTests/ContentTypeTests.swift
+++ b/Tests/OpenAPIKitCoreTests/ContentTypeTests.swift
@@ -66,6 +66,17 @@ final class ContentTypeTests: XCTestCase {
         }
     }
 
+    func test_x_yaml() {
+        // test that we support old x-yaml type but also prefer new official media type
+        let type1 = Shared.ContentType.init(rawValue: "application/yaml")
+        let type2 = Shared.ContentType.init(rawValue: "application/x-yaml")
+
+        XCTAssertEqual(type1?.rawValue, "application/yaml")
+        XCTAssertEqual(type1, .yaml)
+        XCTAssertEqual(type2?.rawValue, "application/yaml")
+        XCTAssertEqual(type2, .yaml)
+    }
+
     func test_goodParam() {
         let type = Shared.ContentType.init(rawValue: "text/html; charset=utf8")
         XCTAssertEqual(type?.warnings.count, 0)


### PR DESCRIPTION
Closes #423

## Breaking
- Support for decoding the `application/x-yaml` media type has been retained, but it will now be re-encoded as `application/yaml`.