### PR TITLE
Clearly indicate that this library is the MIT License.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright 2020 Mathew Polzin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
Often, library users need to identify if the license is permissive for use as OSS. 
The body of the LICENSE is not explicitly stated as the MIT License because it was manually created rather than auto-generated by GitHub. 
The commit logs suggest an intent for the MIT License, so could you please explicitly state it if possible?