### PR TITLE
support stricter reference validations

### DIFF
--- a/Sources/OpenAPIKit/Validator/ReferenceValidations.swift
+++ b/Sources/OpenAPIKit/Validator/ReferenceValidations.swift
@@ -13,14 +13,17 @@ extension Validation {
         /// given type that point at the Components Object are found in the
         /// document's components dictionary. You can choose whether an
         /// internal reference to somewhere other than the components
-        /// dictionary should pass or fail.
-        internal static func referencesAreValid<ReferenceType: ComponentDictionaryLocatable>(ofType type: ReferenceType.Type, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<ReferenceType>> {
-            .init(
-                description: "OpenAPI \(String(describing: type)) reference can be found in components/\(ReferenceType.openAPIComponentsKey)",
+        /// dictionary should pass or fail. You can also choose whether
+        /// external references should fail or pass.
+        internal static func referencesAreValid<ReferenceType: ComponentDictionaryLocatable>(ofType type: ReferenceType.Type, named name: String, mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<ReferenceType>> {
+            let requireInternalAddendum = if requireInternal { " points to this document and" } else { "" }
+
+            return .init(
+                description: "\(name) reference\(requireInternalAddendum) can be found in components/\(ReferenceType.openAPIComponentsKey)",
                 check: { context in
                     guard case let .internal(internalReference) = context.subject.jsonReference else {
-                        // don't make assertions about external references
-                        return true
+                        // don't make assertions about external references other than if we are requiring references to be internal
+                        return !requireInternal
                     }
 
                     guard case .component = internalReference else {
@@ -34,17 +37,19 @@ extension Validation {
             )
         }
 
-        internal static func schemaReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<JSONSchema>> {
-            referencesAreValid(ofType: JSONSchema.self, mustPointToComponents: requireComponents)
+        internal static func schemaReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<JSONSchema>> {
+            referencesAreValid(ofType: JSONSchema.self, named: "JSONSchema", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func jsonSchemaReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<JSONSchema> {
-            .init(
-                description: "JSONSchema reference can be found in components/schemas",
+        internal static func jsonSchemaReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<JSONSchema> {
+            let requireInternalAddendum = if requireInternal { " points to this document and" } else { "" }
+
+            return .init(
+                description: "JSONSchema reference\(requireInternalAddendum) can be found in components/schemas",
                 check: { context in
-                    guard case let .internal(internalReference) = context.subject.reference else {
+                    guard case let .internal(internalReference) = context.subject.reference  else {
                         // don't make assertions about external references
-                        return true
+                        return !requireInternal
                     }
 
                     guard case .component = internalReference else {
@@ -54,40 +59,41 @@ extension Validation {
                         return !requireComponents
                     }
                     return context.document.components.contains(internalReference)
-                }
+                },
+                when: \.reference != nil
             )
         }
 
-        internal static func responseReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Response>> {
-            referencesAreValid(ofType: OpenAPI.Response.self, mustPointToComponents: requireComponents)
+        internal static func responseReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Response>> {
+            referencesAreValid(ofType: OpenAPI.Response.self, named: "Response", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func parameterReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
-            referencesAreValid(ofType: OpenAPI.Parameter.self, mustPointToComponents: requireComponents)
+        internal static func parameterReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
+            referencesAreValid(ofType: OpenAPI.Parameter.self, named: "Parameter", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func exampleReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Example>> {
-            referencesAreValid(ofType: OpenAPI.Example.self, mustPointToComponents: requireComponents)
+        internal static func exampleReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Example>> {
+            referencesAreValid(ofType: OpenAPI.Example.self, named: "Example", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func requestReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Request>> {
-            referencesAreValid(ofType: OpenAPI.Request.self, mustPointToComponents: requireComponents)
+        internal static func requestReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Request>> {
+            referencesAreValid(ofType: OpenAPI.Request.self, named: "Request", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func headerReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Header>> {
-            referencesAreValid(ofType: OpenAPI.Header.self, mustPointToComponents: requireComponents)
+        internal static func headerReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Header>> {
+            referencesAreValid(ofType: OpenAPI.Header.self, named: "Header", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func linkReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Link>> {
-            referencesAreValid(ofType: OpenAPI.Link.self, mustPointToComponents: requireComponents)
+        internal static func linkReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Link>> {
+            referencesAreValid(ofType: OpenAPI.Link.self, named: "Link", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func callbacksReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Callbacks>> {
-            referencesAreValid(ofType: OpenAPI.Callbacks.self, mustPointToComponents: requireComponents)
+        internal static func callbacksReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Callbacks>> {
+            referencesAreValid(ofType: OpenAPI.Callbacks.self, named: "Callbacks", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
 
-        internal static func pathItemReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
-            referencesAreValid(ofType: OpenAPI.PathItem.self, mustPointToComponents: requireComponents)
+        internal static func pathItemReferencesAreValid(mustBeInternal requireInternal: Bool, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
+            referencesAreValid(ofType: OpenAPI.PathItem.self, named: "PathItem", mustBeInternal: requireInternal, mustPointToComponents: requireComponents)
         }
     }
 }

--- a/Sources/OpenAPIKit/Validator/ReferenceValidations.swift
+++ b/Sources/OpenAPIKit/Validator/ReferenceValidations.swift
@@ -1,0 +1,93 @@
+//
+//  ReferenceValidations.swift
+//  
+//
+//  Created by Mathew Polzin on 6/3/20.
+//
+
+import OpenAPIKitCore
+
+extension Validation {
+    internal enum References {
+        /// Create a validation that all non-external OpenAPI references of the
+        /// given type that point at the Components Object are found in the
+        /// document's components dictionary. You can choose whether an
+        /// internal reference to somewhere other than the components
+        /// dictionary should pass or fail.
+        internal static func referencesAreValid<ReferenceType: ComponentDictionaryLocatable>(ofType type: ReferenceType.Type, mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<ReferenceType>> {
+            .init(
+                description: "OpenAPI \(String(describing: type)) reference can be found in components/\(ReferenceType.openAPIComponentsKey)",
+                check: { context in
+                    guard case let .internal(internalReference) = context.subject.jsonReference else {
+                        // don't make assertions about external references
+                        return true
+                    }
+
+                    guard case .component = internalReference else {
+                        // we can't currently resolve non-components internal
+                        // references, but we can either consider them
+                        // implicitly valid or not depending on the use-case:
+                        return !requireComponents
+                    }
+                    return context.document.components.contains(internalReference)
+                }
+            )
+        }
+
+        internal static func schemaReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<JSONSchema>> {
+            referencesAreValid(ofType: JSONSchema.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func jsonSchemaReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<JSONSchema> {
+            .init(
+                description: "JSONSchema reference can be found in components/schemas",
+                check: { context in
+                    guard case let .internal(internalReference) = context.subject.reference else {
+                        // don't make assertions about external references
+                        return true
+                    }
+
+                    guard case .component = internalReference else {
+                        // we can't currently resolve non-components internal
+                        // references, but we can either consider them
+                        // implicitly valid or not depending on the use-case:
+                        return !requireComponents
+                    }
+                    return context.document.components.contains(internalReference)
+                }
+            )
+        }
+
+        internal static func responseReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Response>> {
+            referencesAreValid(ofType: OpenAPI.Response.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func parameterReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
+            referencesAreValid(ofType: OpenAPI.Parameter.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func exampleReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Example>> {
+            referencesAreValid(ofType: OpenAPI.Example.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func requestReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Request>> {
+            referencesAreValid(ofType: OpenAPI.Request.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func headerReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Header>> {
+            referencesAreValid(ofType: OpenAPI.Header.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func linkReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Link>> {
+            referencesAreValid(ofType: OpenAPI.Link.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func callbacksReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.Callbacks>> {
+            referencesAreValid(ofType: OpenAPI.Callbacks.self, mustPointToComponents: requireComponents)
+        }
+
+        internal static func pathItemReferencesAreValid(mustPointToComponents requireComponents: Bool) -> Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
+            referencesAreValid(ofType: OpenAPI.PathItem.self, mustPointToComponents: requireComponents)
+        }
+    }
+}

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -175,6 +175,30 @@ extension Validation {
         )
     }
 
+    /// Validate the OpenAPI Document's `Links` with operationIds refer to
+    /// Operations that exist in the document.
+    ///
+    /// This validation ensures that Link Objects using operationIds have corresponding
+    /// Operations in the document that have those IDs.
+    ///
+    /// - Important: This is not an included validation by default.
+    public static var linkOperationsExist: Validation<OpenAPI.Link> {
+        .init(
+            description: "Links with operationIds have corresponding Operations",
+            check: { context in
+                guard case let .b(operationId) = context.subject.operation else {
+                    // don't make assertions about Links that don't have operationIds
+                    return true
+                }
+                
+                // Collect all operation IDs from the document
+                let operationIds = context.document.allOperationIds
+                
+                return operationIds.contains(operationId)
+            }
+        )
+    }
+
     // MARK: - Included with `Validator()` by default
 
     // You can start with no validations (not even the defaults below)
@@ -254,224 +278,94 @@ extension Validation {
         )
     }
 
-    /// Validate that all non-external OpenAPI JSONSchema references are found in the document's
-    /// components dictionary.
+    /// Validate that all OpenAPI JSONSchema components references are found in
+    /// the document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var schemaReferencesAreValid: Validation<OpenAPI.Reference<JSONSchema>> {
-        .init(
-            description: "OpenAPI JSONSchema reference can be found in components/schemas",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                    case .component = internalReference else {
-                    // don't make assertions about external references
-                    // TODO: could make a stronger assertion including
-                    // internal references outside of components given
-                    // some way to resolve those references.
-                    return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.schemaReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external JSONSchema references are found in the document's
-    /// components dictionary.
+    /// Validate that all JSONSchema components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var jsonSchemaReferencesAreValid: Validation<JSONSchema> {
-        .init(
-            description: "JSONSchema reference can be found in components/schemas",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.reference,
-                    case .component = internalReference else {
-                    // don't make assertions about external references
-                    // TODO: could make a stronger assertion including
-                    // internal references outside of components given
-                    // some way to resolve those references.
-                    return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.jsonSchemaReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Response references are found in the document's
-    /// components dictionary.
+    /// Validate that all Response components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var responseReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Response>> {
-        .init(
-            description: "Response reference can be found in components/responses",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                    case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.responseReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Parameter references are found in the document's
-    /// components dictionary.
+    /// Validate that all Parameter components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var parameterReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
-        .init(
-            description: "Parameter reference can be found in components/parameters",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                    case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.parameterReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Example references are found in the document's
-    /// components dictionary.
+    /// Validate that all Example components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var exampleReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Example>> {
-        .init(
-            description: "Example reference can be found in components/examples",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                    case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.exampleReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Request references are found in the document's
-    /// components dictionary.
+    /// Validate that all Request components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var requestReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Request>> {
-        .init(
-            description: "Request reference can be found in components/requestBodies",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                    case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.requestReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Header references are found in the document's
-    /// components dictionary.
+    /// Validate that all Header components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var headerReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Header>> {
-        .init(
-            description: "Header reference can be found in components/headers",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                    case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.headerReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Link references are found in the document's
-    /// components dictionary.
+    /// Validate that all Link components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var linkReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Link>> {
-        .init(
-            description: "Link reference can be found in components/links",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                      case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.linkReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external Callbacks references are found in the document's
-    /// components dictionary.
+    /// Validate that all Callbacks components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var callbacksReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Callbacks>> {
-        .init(
-            description: "Callbacks reference can be found in components/callbacks",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                      case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.callbacksReferencesAreValid(mustPointToComponents: false)
     }
 
-    /// Validate that all non-external PathItem references are found in the document's
-    /// components dictionary.
+    /// Validate that all PathItem components references are found in the
+    /// document's components dictionary.
     ///
     /// - Important: This is included in validation by default.
     ///
     public static var pathItemReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
-        .init(
-            description: "PathItem reference can be found in components/pathItems",
-            check: { context in
-                guard case let .internal(internalReference) = context.subject.jsonReference,
-                      case .component = internalReference else {
-                        // don't make assertions about external references
-                        // TODO: could make a stronger assertion including
-                        // internal references outside of components given
-                        // some way to resolve those references.
-                        return true
-                }
-                return context.document.components.contains(internalReference)
-            }
-        )
+        References.pathItemReferencesAreValid(mustPointToComponents: false)
     }
     
     /// Validate that `enum` must not be empty in the document's
@@ -500,30 +394,6 @@ extension Validation {
             check: { context in
                 guard let `enum` = context.subject.`enum` else { return true }
                 return `enum`.contains(context.subject.`default`)
-            }
-        )
-    }
-
-    /// Validate the OpenAPI Document's `Links` with operationIds refer to
-    /// Operations that exist in the document.
-    ///
-    /// This validation ensures that Link Objects using operationIds have corresponding
-    /// Operations in the document that have those IDs.
-    ///
-    /// - Important: This is not an included validation by default.
-    public static var linkOperationsExist: Validation<OpenAPI.Link> {
-        .init(
-            description: "Links with operationIds have corresponding Operations",
-            check: { context in
-                guard case let .b(operationId) = context.subject.operation else {
-                    // don't make assertions about Links that don't have operationIds
-                    return true
-                }
-                
-                // Collect all operation IDs from the document
-                let operationIds = context.document.allOperationIds
-                
-                return operationIds.contains(operationId)
             }
         )
     }

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -525,6 +525,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     public static var parameterStyleAndLocationAreCompatible: Validation<OpenAPI.Parameter> {
         .init(
+            description: "Parameter styles are all compatible with their locations",
             check: all(
                 Validation<OpenAPI.Parameter>(
                     description: "the matrix style can only be used for the path location",

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -199,6 +199,126 @@ extension Validation {
         )
     }
 
+    /// Validate that all OpenAPI JSONSchema references are internal and found
+    /// in the document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `schemaReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var schemaReferencesFoundInComponents: Validation<OpenAPI.Reference<JSONSchema>> {
+        References.schemaReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all JSONSchema references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `jsonSchemaReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var jsonSchemaReferencesFoundInComponents: Validation<JSONSchema> {
+        References.jsonSchemaReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Response references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `responseReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var responseReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Response>> {
+        References.responseReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Parameter references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `parameterReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var parameterReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
+        References.parameterReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Example references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `exampleReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var exampleReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Example>> {
+        References.exampleReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Request references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `requestReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var requestReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Request>> {
+        References.requestReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Header references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `headerReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var headerReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Header>> {
+        References.headerReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Link references are internal and found in the document's
+    /// components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `linkReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var linkReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Link>> {
+        References.linkReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all Callbacks references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `callbacksReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var callbacksReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.Callbacks>> {
+        References.callbacksReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
+    /// Validate that all PathItem references are internal and found in the
+    /// document's components dictionary.
+    ///
+    /// - See also: The similar but distinct default-on validation
+    ///             `pathItemReferencesAreValid`. 
+    ///
+    /// - Important: This is not an included in validation by default.
+    ///
+    public static var pathItemReferencesFoundInComponents: Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
+        References.pathItemReferencesAreValid(mustBeInternal: true, mustPointToComponents: true)
+    }
+
     // MARK: - Included with `Validator()` by default
 
     // You can start with no validations (not even the defaults below)
@@ -284,7 +404,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var schemaReferencesAreValid: Validation<OpenAPI.Reference<JSONSchema>> {
-        References.schemaReferencesAreValid(mustPointToComponents: false)
+        References.schemaReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all JSONSchema components references are found in the
@@ -293,7 +413,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var jsonSchemaReferencesAreValid: Validation<JSONSchema> {
-        References.jsonSchemaReferencesAreValid(mustPointToComponents: false)
+        References.jsonSchemaReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Response components references are found in the
@@ -302,7 +422,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var responseReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Response>> {
-        References.responseReferencesAreValid(mustPointToComponents: false)
+        References.responseReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Parameter components references are found in the
@@ -311,7 +431,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var parameterReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
-        References.parameterReferencesAreValid(mustPointToComponents: false)
+        References.parameterReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Example components references are found in the
@@ -320,7 +440,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var exampleReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Example>> {
-        References.exampleReferencesAreValid(mustPointToComponents: false)
+        References.exampleReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Request components references are found in the
@@ -329,7 +449,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var requestReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Request>> {
-        References.requestReferencesAreValid(mustPointToComponents: false)
+        References.requestReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Header components references are found in the
@@ -338,7 +458,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var headerReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Header>> {
-        References.headerReferencesAreValid(mustPointToComponents: false)
+        References.headerReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Link components references are found in the
@@ -347,7 +467,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var linkReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Link>> {
-        References.linkReferencesAreValid(mustPointToComponents: false)
+        References.linkReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all Callbacks components references are found in the
@@ -356,7 +476,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var callbacksReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Callbacks>> {
-        References.callbacksReferencesAreValid(mustPointToComponents: false)
+        References.callbacksReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
 
     /// Validate that all PathItem components references are found in the
@@ -365,7 +485,7 @@ extension Validation {
     /// - Important: This is included in validation by default.
     ///
     public static var pathItemReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
-        References.pathItemReferencesAreValid(mustPointToComponents: false)
+        References.pathItemReferencesAreValid(mustBeInternal: false, mustPointToComponents: false)
     }
     
     /// Validate that `enum` must not be empty in the document's

--- a/Sources/OpenAPIKit/Validator/Validation.swift
+++ b/Sources/OpenAPIKit/Validator/Validation.swift
@@ -42,6 +42,8 @@ public struct Validation<Subject: Validatable> {
     /// - The coding path where the validation is occurring.
     public let predicate: (ValidationContext<Subject>) -> Bool
 
+    public let description: String
+
     /// Apply the validation to the given value if the predicate
     /// returns `true`.
     public func apply(to subject: Subject, at codingPath: [CodingKey], in document: OpenAPI.Document) -> [ValidationError] {
@@ -62,6 +64,8 @@ public struct Validation<Subject: Validatable> {
     /// all values of the type your `validate` method operates on.
     ///
     /// - Parameters:
+    ///     - description: A description of the correct state described by the
+    ///         `validate` function. If not given will default to the description of the type.
     ///     - validate: A function taking validation contexts containing
     ///         subjects of type `Subject` and validating them. This function must
     ///         return an array of errors. If validation succeeds, return an empty
@@ -70,11 +74,13 @@ public struct Validation<Subject: Validatable> {
     ///         should run against the given value.
     ///
     public init(
+        description: String? = nil,
         check validate: @escaping (ValidationContext<Subject>) -> [ValidationError],
         when predicate: @escaping (ValidationContext<Subject>) -> Bool = { _ in true }
     ) {
         self.validate = validate
         self.predicate = predicate
+        self.description = description ?? String(describing: Self.self)
     }
 
     /// Create a Validation with a single error that applies to values of type `Subject`.
@@ -103,7 +109,7 @@ public struct Validation<Subject: Validatable> {
                 ? []
                 : [ ValidationError(reason: "Failed to satisfy: \(description)", at: context.codingPath) ]
         }
-        self.init(check: validity, when: predicate)
+        self.init(description: description, check: validity, when: predicate)
     }
 }
 
@@ -166,7 +172,11 @@ internal struct AnyValidation {
         return _apply(value, codingPath, document)
     }
 
+    /// A description of the correct or desirable outcome being validated.
+    public let description: String
+
     init<T>(_ validation: Validation<T>) {
+        self.description = validation.description
         self._apply = { input, codingPath, document in
 
             guard let subject = input as? T else {

--- a/Sources/OpenAPIKit/Validator/Validator.swift
+++ b/Sources/OpenAPIKit/Validator/Validator.swift
@@ -181,6 +181,10 @@ public final class Validator {
         nonReferenceDefaultValidations + referenceDefaultValidations + customValidations
     }
 
+    public var validationDescriptions: [String] {
+        validations.map(\.description)
+    }
+
     /// Creates a `Validator` with exactly the given validations.
     ///
     /// - Important: Default builtin validations are not run if the Validator is creaated with this initializer.
@@ -298,11 +302,9 @@ extension Validator {
     /// By default, all references must be "valid" but that allows for internal
     /// references that do not live in the Components Object.
     public func validatingAllReferencesFoundInComponents() -> Self {
-        // turn off the less strict default reference validations as they are
+        // replace the less strict default reference validations as they are
         // encompassed by the stricter validations:
-        referenceDefaultValidations = []
-
-        customValidations.append(contentsOf: [
+        referenceDefaultValidations = [
             .init(.schemaReferencesFoundInComponents),
             .init(.jsonSchemaReferencesFoundInComponents),
             .init(.responseReferencesFoundInComponents),
@@ -313,7 +315,17 @@ extension Validator {
             .init(.linkReferencesFoundInComponents),
             .init(.callbacksReferencesFoundInComponents),
             .init(.pathItemReferencesFoundInComponents)
-        ])
+        ]
+        return self
+    }
+
+    /// Skip validations that references are internal or can be looked up in
+    /// the Components Object.
+    ///
+    /// By default, all references must be "valid" but that allows for internal
+    /// references that do not live in the Components Object. If you skip reference validations then nothing about references will be validated.
+    public func skippingReferenceValidations() -> Self {
+        referenceDefaultValidations = []
         return self
     }
 }

--- a/Sources/OpenAPIKit/Validator/Validator.swift
+++ b/Sources/OpenAPIKit/Validator/Validator.swift
@@ -152,18 +152,47 @@ extension OpenAPI.Document {
 ///
 public final class Validator {
 
-    internal var validations: [AnyValidation]
+    internal var customValidations: [AnyValidation]
 
-    /// Creates a `Validator`.
-    internal init(validations: [AnyValidation]) {
-        self.validations = validations
+    internal var nonReferenceDefaultValidations: [AnyValidation] = [
+        .init(.documentTagNamesAreUnique),
+        .init(.pathItemParametersAreUnique),
+        .init(.operationParametersAreUnique),
+        .init(.operationIdsAreUnique),
+        .init(.serverVariableEnumIsValid),
+        .init(.serverVariableDefaultExistsInEnum),
+        .init(.parameterStyleAndLocationAreCompatible)
+    ]
+
+    internal var referenceDefaultValidations: [AnyValidation] = [
+        .init(.schemaReferencesAreValid),
+        .init(.jsonSchemaReferencesAreValid),
+        .init(.responseReferencesAreValid),
+        .init(.parameterReferencesAreValid),
+        .init(.exampleReferencesAreValid),
+        .init(.requestReferencesAreValid),
+        .init(.headerReferencesAreValid),
+        .init(.linkReferencesAreValid),
+        .init(.callbacksReferencesAreValid),
+        .init(.pathItemReferencesAreValid)
+    ]
+
+    internal var validations: [AnyValidation] {
+        nonReferenceDefaultValidations + referenceDefaultValidations + customValidations
     }
 
-    /// Creates the default `Validator`. Note that
-    /// this Validator will perform the default validations.
-    /// If you want a Validator that won't perform any
-    /// validations except the ones you add, use
-    /// `Validator.blank`.
+    /// Creates a `Validator` with exactly the given validations.
+    ///
+    /// - Important: Default builtin validations are not run if the Validator is creaated with this initializer.
+    internal init(validations: [AnyValidation]) {
+        self.referenceDefaultValidations = []
+        self.nonReferenceDefaultValidations = []
+        self.customValidations = validations
+    }
+
+    /// Creates the default `Validator`. Note that this Validator will perform
+    /// the default validations. If you want a Validator that won't perform any
+    /// validations except the ones you add, use `Validator.blank`.
     ///
     /// The default validations are
     /// - Document-level tag names are unique.
@@ -177,37 +206,18 @@ public final class Validator {
     ///     Variable.
     /// - `Parameter` styles and locations are compatible with each other.
     ///
-    public convenience init() {
-        self.init(validations: [
-            .init(.documentTagNamesAreUnique),
-            .init(.pathItemParametersAreUnique),
-            .init(.operationParametersAreUnique),
-            .init(.operationIdsAreUnique),
-            .init(.schemaReferencesAreValid),
-            .init(.jsonSchemaReferencesAreValid),
-            .init(.responseReferencesAreValid),
-            .init(.parameterReferencesAreValid),
-            .init(.exampleReferencesAreValid),
-            .init(.requestReferencesAreValid),
-            .init(.headerReferencesAreValid),
-            .init(.linkReferencesAreValid),
-            .init(.callbacksReferencesAreValid),
-            .init(.pathItemReferencesAreValid),
-            .init(.serverVariableEnumIsValid),
-            .init(.serverVariableDefaultExistsInEnum),
-            .init(.parameterStyleAndLocationAreCompatible)
-        ])
+    public init() {
+        self.customValidations = []
     }
 
-    /// A validator with no validation rules at all (not
-    /// even the defaults).
+    /// A validator with no validation rules at all (not even the defaults).
     public static var blank: Validator {
         return Self.init(validations: [])
     }
 
     /// Add a validation to be performed.
     public func validating<T: Encodable>(_ validation: Validation<T>) -> Self {
-        validations.append(AnyValidation(validation))
+        customValidations.append(AnyValidation(validation))
         return self
     }
 
@@ -278,6 +288,33 @@ public final class Validator {
         }
 
         return validating(validity, when: predicate)
+    }
+}
+
+extension Validator {
+    /// Add validations that all references are internal can be looked up in
+    /// the Components Object.
+    ///
+    /// By default, all references must be "valid" but that allows for internal
+    /// references that do not live in the Components Object.
+    public func validatingAllReferencesFoundInComponents() -> Self {
+        // turn off the less strict default reference validations as they are
+        // encompassed by the stricter validations:
+        referenceDefaultValidations = []
+
+        customValidations.append(contentsOf: [
+            .init(.schemaReferencesFoundInComponents),
+            .init(.jsonSchemaReferencesFoundInComponents),
+            .init(.responseReferencesFoundInComponents),
+            .init(.parameterReferencesFoundInComponents),
+            .init(.exampleReferencesFoundInComponents),
+            .init(.requestReferencesFoundInComponents),
+            .init(.headerReferencesFoundInComponents),
+            .init(.linkReferencesFoundInComponents),
+            .init(.callbacksReferencesFoundInComponents),
+            .init(.pathItemReferencesFoundInComponents)
+        ])
+        return self
     }
 }
 

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -13,6 +13,73 @@ import OpenAPIKit
 
 final class BuiltinValidationTests: XCTestCase {
 
+    func test_variousConfigurationsHaveExpectedValidationCounts() {
+        let blank = Validator.blank
+        XCTAssertEqual(blank.validationDescriptions.count, 0)
+
+        let singleCustom = Validator.blank.validating(.pathItemReferencesAreValid)
+        XCTAssertEqual(singleCustom.validationDescriptions.count, 1)
+        XCTAssertEqual(singleCustom.validationDescriptions, [
+            "PathItem reference can be found in components/pathItems"
+        ])
+
+        let withoutReferenceValidations = Validator().skippingReferenceValidations()
+        XCTAssertEqual(withoutReferenceValidations.validationDescriptions.count, 7)
+        XCTAssertEqual(withoutReferenceValidations.validationDescriptions, [
+            "The names of Tags in the Document are unique",
+            "Path Item parameters are unique (identity is defined by the \'name\' and \'location\')",
+            "Operation parameters are unique (identity is defined by the \'name\' and \'location\')",
+            "All Operation Ids in Document are unique",
+            "Server Variable\'s enum is either not defined or is non-empty (if defined).",
+            "Server Variable\'s default must exist in enum, if enum is defined.",
+            "Parameter styles are all compatible with their locations"
+        ])
+
+        let defaultValidations = Validator()
+        XCTAssertEqual(defaultValidations.validationDescriptions.count, 17)
+        XCTAssertEqual(defaultValidations.validationDescriptions, [
+            "The names of Tags in the Document are unique",
+            "Path Item parameters are unique (identity is defined by the \'name\' and \'location\')",
+            "Operation parameters are unique (identity is defined by the \'name\' and \'location\')",
+            "All Operation Ids in Document are unique",
+            "Server Variable\'s enum is either not defined or is non-empty (if defined).",
+            "Server Variable\'s default must exist in enum, if enum is defined.",
+            "Parameter styles are all compatible with their locations",
+            "JSONSchema reference can be found in components/schemas",
+            "JSONSchema reference can be found in components/schemas",
+            "Response reference can be found in components/responses",
+            "Parameter reference can be found in components/parameters",
+            "Example reference can be found in components/examples",
+            "Request reference can be found in components/requestBodies",
+            "Header reference can be found in components/headers",
+            "Link reference can be found in components/links",
+            "Callbacks reference can be found in components/callbacks",
+            "PathItem reference can be found in components/pathItems"
+        ])
+
+        let stricterReferenceValidations = Validator().validatingAllReferencesFoundInComponents()
+        XCTAssertEqual(stricterReferenceValidations.validationDescriptions.count, 17)
+        XCTAssertEqual(stricterReferenceValidations.validationDescriptions, [
+            "The names of Tags in the Document are unique",
+            "Path Item parameters are unique (identity is defined by the \'name\' and \'location\')",
+            "Operation parameters are unique (identity is defined by the \'name\' and \'location\')",
+            "All Operation Ids in Document are unique",
+            "Server Variable\'s enum is either not defined or is non-empty (if defined).",
+            "Server Variable\'s default must exist in enum, if enum is defined.",
+            "Parameter styles are all compatible with their locations",
+            "JSONSchema reference points to this document and can be found in components/schemas",
+            "JSONSchema reference points to this document and can be found in components/schemas",
+            "Response reference points to this document and can be found in components/responses",
+            "Parameter reference points to this document and can be found in components/parameters",
+            "Example reference points to this document and can be found in components/examples",
+            "Request reference points to this document and can be found in components/requestBodies",
+            "Header reference points to this document and can be found in components/headers",
+            "Link reference points to this document and can be found in components/links",
+            "Callbacks reference points to this document and can be found in components/callbacks",
+            "PathItem reference points to this document and can be found in components/pathItems"
+        ])
+    }
+
     func test_noPathsOnDocumentFails() {
         let document = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
@@ -1035,7 +1102,28 @@ final class BuiltinValidationTests: XCTestCase {
         let validator = Validator.blank.validating(.linkOperationsExist)
         try document.validate(using: validator)
     }
-    
+
+    func test_linkOperationNoId_succeeds() throws {
+        // Create a link without an operationId
+        let link = OpenAPI.Link(operation: .a(URL(string: "https://operation.com")!))
+
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello": .init()
+            ],
+            components: .direct(
+                links: [
+                    "testLink": link
+                ]
+            )
+        )
+
+        let validator = Validator.blank.validating(.linkOperationsExist)
+        try document.validate(using: validator)
+    }
+
     func test_linkOperationsExist_fails() throws {
         // Create a link with an operationId that doesn't exist in the document
         let link = OpenAPI.Link(operationId: "nonExistentOperation")

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -791,7 +791,7 @@ final class BuiltinValidationTests: XCTestCase {
         }
     }
 
-    func test_oneOfEachReferenceTypeSucceeds() throws {
+    fileprivate var oneOfEachReference: OpenAPI.Document {
         let path = OpenAPI.PathItem(
             put: .init(
                 requestBody: .reference(.external(URL(string: "https://website.com/file.json#/hello/world")!)),
@@ -832,7 +832,8 @@ final class BuiltinValidationTests: XCTestCase {
                     )
                 ],
                 callbacks: [
-                  "callbacks1": .reference(.component(named: "callbacks1"))
+                    "callbacks1": .reference(.component(named: "callbacks1")),
+                    "callbacks2": .reference(.external(URL(string: "https://callbacks.com")!))
                 ]
             )
         )
@@ -868,7 +869,7 @@ final class BuiltinValidationTests: XCTestCase {
                     "link1": .init(operationId: "op 1")
                 ],
                 callbacks: [
-                  "callbacks1": .init()
+                    "callbacks1": .init()
                 ],
                 pathItems: [
                     "path1": .init()
@@ -876,8 +877,115 @@ final class BuiltinValidationTests: XCTestCase {
             )
         )
 
+        return document
+    }
+
+    func test_oneOfEachReferenceTypeSucceeds() throws {
+        let document = oneOfEachReference
+
         // NOTE this is part of default validation
         try document.validate()
+    }
+
+    func test_oneOfEachInternalReferenceTypeSucceedsComponentValidation() throws {
+        let document = oneOfEachReference
+
+        // NOTE this is NOT part of default validation
+        let validator = Validator().validatingAllReferencesFoundInComponents()
+        // NOTE this _will_ still fail but only for the external references
+        XCTAssertThrowsError(try document.validate(using: validator)) { error in
+            let error = error as? ValidationErrorCollection
+            XCTAssertEqual(error?.values.count, 9)
+            XCTAssertEqual(error?.values[0].reason, "Failed to satisfy: Request reference points to this document and can be found in components/requestBodies")
+            XCTAssertEqual(error?.values[0].codingPathString, ".paths['/hello'].put.requestBody")
+            XCTAssertEqual(error?.values[1].reason, "Failed to satisfy: Parameter reference points to this document and can be found in components/parameters")
+            XCTAssertEqual(error?.values[1].codingPathString, ".paths['/hello'].post.parameters[1]")
+            XCTAssertEqual(error?.values[2].reason, "Failed to satisfy: Response reference points to this document and can be found in components/responses")
+            XCTAssertEqual(error?.values[2].codingPathString, ".paths['/hello'].post.responses.301")
+            XCTAssertEqual(error?.values[3].reason, "Failed to satisfy: Header reference points to this document and can be found in components/headers")
+            XCTAssertEqual(error?.values[3].codingPathString, ".paths['/hello'].post.responses.404.headers.external")
+            XCTAssertEqual(error?.values[4].reason, "Failed to satisfy: Example reference points to this document and can be found in components/examples")
+            XCTAssertEqual(error?.values[4].codingPathString, ".paths['/hello'].post.responses.404.content['application/json'].examples.external")
+            XCTAssertEqual(error?.values[5].reason, "Failed to satisfy: JSONSchema reference points to this document and can be found in components/schemas")
+            XCTAssertEqual(error?.values[5].codingPathString, ".paths['/hello'].post.responses.404.content['text/plain'].schema")
+            XCTAssertEqual(error?.values[6].reason, "Failed to satisfy: Link reference points to this document and can be found in components/links")
+            XCTAssertEqual(error?.values[6].codingPathString, ".paths['/hello'].post.responses.404.links.linky2")
+            XCTAssertEqual(error?.values[7].reason, "Failed to satisfy: Callbacks reference points to this document and can be found in components/callbacks")
+            XCTAssertEqual(error?.values[7].codingPathString, ".paths['/hello'].post.callbacks.callbacks2")
+            XCTAssertEqual(error?.values[8].reason, "Failed to satisfy: PathItem reference points to this document and can be found in components/pathItems")
+            XCTAssertEqual(error?.values[8].codingPathString, ".paths['/external']")
+        }
+    }
+
+    func test_oneOfEachReferenceTypeFailsComponentValidationIfNotInComponents() throws {
+        var document = oneOfEachReference
+        document.components = .noComponents
+
+        // NOTE this is NOT part of default validation
+        let validator = Validator().validatingAllReferencesFoundInComponents()
+        XCTAssertThrowsError(try document.validate(using: validator)) { error in
+            let error = error as? ValidationErrorCollection
+            XCTAssertEqual(error?.values.count, 18)
+            XCTAssertEqual(error?.values[0].reason, "Failed to satisfy: Request reference points to this document and can be found in components/requestBodies")
+            XCTAssertEqual(error?.values[0].codingPathString, ".paths['/hello'].put.requestBody")
+            XCTAssertEqual(error?.values[1].reason, "Failed to satisfy: Parameter reference points to this document and can be found in components/parameters")
+            XCTAssertEqual(error?.values[1].codingPathString, ".paths['/hello'].post.parameters[0]")
+            XCTAssertEqual(error?.values[2].reason, "Failed to satisfy: Parameter reference points to this document and can be found in components/parameters")
+            XCTAssertEqual(error?.values[2].codingPathString, ".paths['/hello'].post.parameters[1]")
+            XCTAssertEqual(error?.values[3].reason, "Failed to satisfy: Request reference points to this document and can be found in components/requestBodies")
+            XCTAssertEqual(error?.values[3].codingPathString, ".paths['/hello'].post.requestBody")
+            XCTAssertEqual(error?.values[4].reason, "Failed to satisfy: Response reference points to this document and can be found in components/responses")
+            XCTAssertEqual(error?.values[4].codingPathString, ".paths['/hello'].post.responses.200")
+            XCTAssertEqual(error?.values[5].reason, "Failed to satisfy: Response reference points to this document and can be found in components/responses")
+            XCTAssertEqual(error?.values[5].codingPathString, ".paths['/hello'].post.responses.301")
+            XCTAssertEqual(error?.values[6].reason, "Failed to satisfy: Header reference points to this document and can be found in components/headers")
+            XCTAssertEqual(error?.values[6].codingPathString, ".paths['/hello'].post.responses.404.headers.header1")
+            XCTAssertEqual(error?.values[7].reason, "Failed to satisfy: Header reference points to this document and can be found in components/headers")
+            XCTAssertEqual(error?.values[7].codingPathString, ".paths['/hello'].post.responses.404.headers.external")
+            XCTAssertEqual(error?.values[8].reason, "Failed to satisfy: Example reference points to this document and can be found in components/examples")
+            XCTAssertEqual(error?.values[8].codingPathString, ".paths['/hello'].post.responses.404.content['application/json'].examples.example1")
+            XCTAssertEqual(error?.values[9].reason, "Failed to satisfy: Example reference points to this document and can be found in components/examples")
+            XCTAssertEqual(error?.values[9].codingPathString, ".paths['/hello'].post.responses.404.content['application/json'].examples.external")
+            XCTAssertEqual(error?.values[10].reason, "Failed to satisfy: JSONSchema reference points to this document and can be found in components/schemas")
+            XCTAssertEqual(error?.values[10].codingPathString, ".paths['/hello'].post.responses.404.content['application/xml'].schema")
+            XCTAssertEqual(error?.values[11].reason, "Failed to satisfy: JSONSchema reference points to this document and can be found in components/schemas")
+            XCTAssertEqual(error?.values[11].codingPathString, ".paths['/hello'].post.responses.404.content['text/plain'].schema")
+            XCTAssertEqual(error?.values[12].reason, "Failed to satisfy: Link reference points to this document and can be found in components/links")
+            XCTAssertEqual(error?.values[12].codingPathString, ".paths['/hello'].post.responses.404.links.linky")
+            XCTAssertEqual(error?.values[13].reason, "Failed to satisfy: Link reference points to this document and can be found in components/links")
+            XCTAssertEqual(error?.values[13].codingPathString, ".paths['/hello'].post.responses.404.links.linky2")
+            XCTAssertEqual(error?.values[14].reason, "Failed to satisfy: Callbacks reference points to this document and can be found in components/callbacks")
+            XCTAssertEqual(error?.values[14].codingPathString, ".paths['/hello'].post.callbacks.callbacks1")
+            XCTAssertEqual(error?.values[15].reason, "Failed to satisfy: Callbacks reference points to this document and can be found in components/callbacks")
+            XCTAssertEqual(error?.values[15].codingPathString, ".paths['/hello'].post.callbacks.callbacks2")
+            XCTAssertEqual(error?.values[16].reason, "Failed to satisfy: PathItem reference points to this document and can be found in components/pathItems")
+            XCTAssertEqual(error?.values[16].codingPathString, ".paths['/world']")
+            XCTAssertEqual(error?.values[17].reason, "Failed to satisfy: PathItem reference points to this document and can be found in components/pathItems")
+            XCTAssertEqual(error?.values[17].codingPathString, ".paths['/external']")
+        }
+    }
+
+    func test_internalReferenceToNonComponentFailsFoundInComponents() throws {
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/internal": .reference(.internal(path: "#/not/important/where"))
+            ],
+            components: .noComponents
+        )
+
+        // Document will pass less strict default validations
+        try document.validate()
+
+        // Document will fail stricter reference found in component validations
+        let validator = Validator().validatingAllReferencesFoundInComponents()
+        XCTAssertThrowsError(try document.validate(using: validator)) { error in
+            let error = error as? ValidationErrorCollection
+            XCTAssertEqual(error?.values.count, 1)
+            XCTAssertEqual(error?.values[0].reason, "Failed to satisfy: PathItem reference points to this document and can be found in components/pathItems")
+            XCTAssertEqual(error?.values[0].codingPathString, ".paths['/internal']")
+        }
     }
 
     func test_pathItemsTopLevelReferencesReferencingPathItemComponentsSuccess() throws {


### PR DESCRIPTION
<!--
## GitHub Issue
support stricter reference validations
--

-->
In addition to validations that all references are "valid" (which skips over internal references not pointing to the Components Object), add validations that require all internal references to point at the Compoments Object. The latter validations should be optional.

Closes #484
