### PR TITLE
Update iOS minimum deployment target to 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "OpenAPIKit",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v12)
+        .iOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
Fixes compiler errors caused by Swift concurrency features (async/await) that require iOS 13.0 or later. The codebase uses async/await extensively but Package.swift was declaring iOS 11 or 12 as minimum, causing build failures when adding OpenAPIKit as a dependency.

Fixes: https://github.com/mattpolzin/OpenAPIKit/issues/493