### PR TITLE
feat: externally dereference `$dynamicRef`

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -729,12 +729,12 @@ extension JSONSchema: ExternallyDereferenceable {
             newSchema = .init(
                 schema: .reference(newReference, core)
             )
-        case .dynamicReference:
-            // TODO: external dereferencing of `$dynamicRef` is not implemented;
-            //       deferred alongside local dynamic-scope resolution (see #359).
-            newComponents = .noComponents
-            newSchema = self
-            newMessages = []
+        case .dynamicReference(let dynamicRef, let core):
+            // Delegate to the wrapped JSONReference's external deref (same path as $ref).
+            let (newReference, components, messages) = try await dynamicRef.jsonReference.externallyDereferenced(with: loader)
+            newComponents = components
+            newMessages = messages
+            newSchema = .init(schema: .dynamicReference(JSONDynamicReference(newReference), core))
         case .fragment(_): 
             newComponents = .noComponents
             newSchema = self

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaDynamicReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaDynamicReferenceTests.swift
@@ -439,3 +439,36 @@ final class JSONSchemaDynamicReferenceTests: XCTestCase {
         }
     }
 }
+
+#if ExternalLoading
+extension JSONSchemaDynamicReferenceTests {
+    func test_externalDeref_dynamicReference_external() async throws {
+        // An external `$dynamicRef` is dereferenced through its underlying
+        // `JSONReference` -- same path as `$ref`: fetch + convert to an
+        // internal component reference.
+        let schema = JSONSchema.dynamicReference(
+            JSONDynamicReference(.external(.init(string: "./schema.json")!))
+        )
+
+        let (newSchema, components, messages) = try await schema.externallyDereferenced(with: JSONReferenceTests.SchemaLoader.self)
+
+        XCTAssertTrue(newSchema.isDynamicReference)
+        XCTAssertEqual(newSchema.dynamicReference?.name, "__schema_json")
+        XCTAssertEqual(components, .init(schemas: ["__schema_json": .string]))
+        XCTAssertEqual(messages, ["./schema.json"])
+    }
+
+    func test_externalDeref_dynamicReference_internal_noop() async throws {
+        // An internal `$dynamicRef` (anchor) is not external; external
+        // dereferencing leaves it unchanged.
+        let schema = JSONSchema.dynamicReference(.anchor("node"))
+
+        let (newSchema, components, messages) = try await schema.externallyDereferenced(with: JSONReferenceTests.SchemaLoader.self)
+
+        XCTAssertTrue(newSchema.isDynamicReference)
+        XCTAssertEqual(newSchema.dynamicReference?.absoluteString, "#node")
+        XCTAssertTrue(components.schemas.isEmpty)
+        XCTAssertEqual(messages, [])
+    }
+}
+#endif


### PR DESCRIPTION
Part of #359.

Implements the "External dereferencing of `$dynamicRef`" item from the #359 task list. The `.dynamicReference` case of `externallyDereferenced(with:)` previously passed through unchanged (with a TODO); it now delegates to the wrapped `JSONReference`'s external deref — reusing the same tested path `$ref` uses.

- **External `$dynamicRef`** (target is an external URI): fetched via the supplied `ExternalLoader` and rewritten to an internal component reference.
- **Internal `$dynamicRef`** (anchor): unchanged (external deref is a no-op for internal refs, mirroring `$ref`).
- The result remains a `.dynamicReference` (still serializes as `$dynamicRef`), preserving the dynamic-anchor semantic. Cross-document dynamic-scope resolution stays out of scope (tracked separately in #359).

## Testing

- 2 new tests (external → loaded component; internal → no-op), reusing the existing `SchemaLoader` mock.
- Full suite passes locally after rebase onto `release/7_0` (which now includes #504 — local dynamic-scope resolution).
- v7 migration guide updated: this PR adds the "External dereferencing resolves `$dynamicRef`" section alongside the existing local-resolution section from #504.

---
*This PR was drafted with assistance from AI tooling. The submitter has reviewed and validated the contents prior to submission.*
