### PR TITLE
feat: resolve `$dynamicRef` against the dynamic scope

### DIFF
--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -599,15 +599,23 @@ extension JSONReference: LocallyDereferenceable where ReferenceType: LocallyDere
         following references: Set<AnyHashable>,
         dereferencedFromComponentNamed name: String?
     ) throws -> ReferenceType.DereferencedSelf {
+        try _dereferenced(in: components, following: references) { resolved, refs, name in
+            try resolved._dereferenced(in: components, following: refs, dereferencedFromComponentNamed: name)
+        }
+    }
+
+    internal func _dereferenced(
+        in components: OpenAPI.Components,
+        following references: Set<AnyHashable>,
+        then: (ReferenceType, Set<AnyHashable>, String?) throws -> ReferenceType.DereferencedSelf
+    ) throws -> ReferenceType.DereferencedSelf {
         var newReferences = references
         let (inserted, _) = newReferences.insert(self)
         guard inserted else {
             throw OpenAPI.Components.ReferenceCycleError(ref: self.absoluteString)
         }
-
-        return try components
-            .lookup(self)
-            ._dereferenced(in: components, following: newReferences, dereferencedFromComponentNamed: self.name)
+        let resolved = try components.lookup(self)
+        return try then(resolved, newReferences, self.name)
     }
 }
 

--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -486,11 +486,8 @@ extension JSONSchema: LocallyDereferenceable {
     /// Scope-aware dereferencing.
     ///
     /// `dynamicScope` maps a `$dynamicAnchor` name to the **outermost** schema
-    /// resource bearing that anchor on the current resolution path (first-wins
-    /// insertion). A `$dynamicRef` is resolved against this scope per JSON
-    /// Schema 2020-12 dynamic-scope rules: the outermost matching anchor wins.
-    /// Non-recursive targets are inlined; recursive or unresolvable dynamic
-    /// references throw (a `DereferencedJSONSchema` must not contain references).
+    /// resource bearing that anchor on the current resolution path. Non-recursive
+    /// targets are inlined; recursive or unresolvable `$dynamicRef`s throw.
     internal func _dereferenced(
         in components: OpenAPI.Components,
         following references: Set<AnyHashable>,
@@ -505,9 +502,7 @@ extension JSONSchema: LocallyDereferenceable {
             return context.with(vendorExtensions: extensions)
         }
 
-        // Seed the dynamic scope with this schema's own `$dynamicAnchor` and any
-        // declared in its `$defs` (the JSON Schema "generics" pattern). First-wins
-        // keeps the outermost resource's anchor, per the dynamic-scope rules.
+        // `$defs` anchors count as part of this resource (the JSON Schema "generics" pattern).
         var dynamicScope = outerDynamicScope
         if let anchor = self.dynamicAnchor, dynamicScope[anchor] == nil {
             dynamicScope[anchor] = self
@@ -522,15 +517,9 @@ extension JSONSchema: LocallyDereferenceable {
         case .null(let coreContext):
             return .null(addComponentNameExtension(to: coreContext))
         case .reference(let reference, let context):
-            // Thread the dynamic scope across the `$ref` boundary (outermost-wins).
-            var newReferences = references
-            let (inserted, _) = newReferences.insert(reference)
-            guard inserted else {
-                throw OpenAPI.Components.ReferenceCycleError(ref: reference.absoluteString)
+            var dereferenced = try reference._dereferenced(in: components, following: references) { resolved, refs, name in
+                try resolved._dereferenced(in: components, following: refs, dereferencedFromComponentNamed: name, dynamicScope: dynamicScope)
             }
-            var dereferenced = try components
-                .lookup(reference)
-                ._dereferenced(in: components, following: newReferences, dereferencedFromComponentNamed: reference.name, dynamicScope: dynamicScope)
 
             if !context.required {
                 dereferenced = dereferenced.optionalSchemaObject()
@@ -548,9 +537,8 @@ extension JSONSchema: LocallyDereferenceable {
 
             return dereferenced
         case .dynamicReference(let reference, let context):
-            // Resolve `$dynamicRef` against the dynamic scope. Only plain anchor
-            // references participate; component/path/external dynamic refs have no
-            // matching dynamic anchor and throw.
+            // Only `#anchor` dynamic refs bind to the dynamic scope; component/path/external
+            // forms have no scope entry and intentionally throw below.
             if case .internal(.anchor(let anchorName)) = reference.jsonReference,
                let target = dynamicScope[anchorName] {
                 let cycleKey = AnyHashable("dynamicRef:#\(anchorName)")

--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -305,9 +305,10 @@ extension DereferencedJSONSchema {
         internal init(
             _ arrayContext: JSONSchema.ArrayContext,
             resolvingIn components: OpenAPI.Components,
-            following references: Set<AnyHashable>
+            following references: Set<AnyHashable>,
+            dynamicScope: [String: JSONSchema] = [:]
         ) throws {
-            items = try arrayContext.items.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
+            items = try arrayContext.items.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope) }
             maxItems = arrayContext.maxItems
             _minItems = arrayContext._minItems
             _uniqueItems = arrayContext._uniqueItems
@@ -401,17 +402,18 @@ extension DereferencedJSONSchema {
         internal init(
             _ objectContext: JSONSchema.ObjectContext,
             resolvingIn components: OpenAPI.Components,
-            following references: Set<AnyHashable>
+            following references: Set<AnyHashable>,
+            dynamicScope: [String: JSONSchema] = [:]
         ) throws {
-            properties = try objectContext.properties.mapValues { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
-            patternProperties = try objectContext.patternProperties.mapValues { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
+            properties = try objectContext.properties.mapValues { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope) }
+            patternProperties = try objectContext.patternProperties.mapValues { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope) }
             maxProperties = objectContext.maxProperties
             _minProperties = objectContext._minProperties
             switch objectContext.additionalProperties {
             case .a(let bool):
                 additionalProperties = .a(bool)
             case .b(let schema):
-                additionalProperties = .b(try schema._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil))
+                additionalProperties = .b(try schema._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope))
             case nil:
                 additionalProperties = nil
             }
@@ -478,6 +480,23 @@ extension JSONSchema: LocallyDereferenceable {
         following references: Set<AnyHashable>,
         dereferencedFromComponentNamed name: String?
     ) throws -> DereferencedJSONSchema {
+        try _dereferenced(in: components, following: references, dereferencedFromComponentNamed: name, dynamicScope: [:])
+    }
+
+    /// Scope-aware dereferencing.
+    ///
+    /// `dynamicScope` maps a `$dynamicAnchor` name to the **outermost** schema
+    /// resource bearing that anchor on the current resolution path (first-wins
+    /// insertion). A `$dynamicRef` is resolved against this scope per JSON
+    /// Schema 2020-12 dynamic-scope rules: the outermost matching anchor wins.
+    /// Non-recursive targets are inlined; recursive or unresolvable dynamic
+    /// references throw (a `DereferencedJSONSchema` must not contain references).
+    internal func _dereferenced(
+        in components: OpenAPI.Components,
+        following references: Set<AnyHashable>,
+        dereferencedFromComponentNamed name: String?,
+        dynamicScope outerDynamicScope: [String: JSONSchema]
+    ) throws -> DereferencedJSONSchema {
         func addComponentNameExtension<T>(to context: CoreContext<T>) -> CoreContext<T> {
             var extensions = context.vendorExtensions
             if let name {
@@ -486,12 +505,32 @@ extension JSONSchema: LocallyDereferenceable {
             return context.with(vendorExtensions: extensions)
         }
 
+        // Seed the dynamic scope with this schema's own `$dynamicAnchor` and any
+        // declared in its `$defs` (the JSON Schema "generics" pattern). First-wins
+        // keeps the outermost resource's anchor, per the dynamic-scope rules.
+        var dynamicScope = outerDynamicScope
+        if let anchor = self.dynamicAnchor, dynamicScope[anchor] == nil {
+            dynamicScope[anchor] = self
+        }
+        for (_, def) in self.defs {
+            if let defAnchor = def.dynamicAnchor, dynamicScope[defAnchor] == nil {
+                dynamicScope[defAnchor] = def
+            }
+        }
+
         switch value {
         case .null(let coreContext):
             return .null(addComponentNameExtension(to: coreContext))
         case .reference(let reference, let context):
-            var dereferenced = try reference
-                ._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
+            // Thread the dynamic scope across the `$ref` boundary (outermost-wins).
+            var newReferences = references
+            let (inserted, _) = newReferences.insert(reference)
+            guard inserted else {
+                throw OpenAPI.Components.ReferenceCycleError(ref: reference.absoluteString)
+            }
+            var dereferenced = try components
+                .lookup(reference)
+                ._dereferenced(in: components, following: newReferences, dereferencedFromComponentNamed: reference.name, dynamicScope: dynamicScope)
 
             if !context.required {
                 dereferenced = dereferenced.optionalSchemaObject()
@@ -508,14 +547,41 @@ extension JSONSchema: LocallyDereferenceable {
             dereferenced = dereferenced.with(vendorExtensions: extensions)
 
             return dereferenced
-        case .dynamicReference(let reference, _):
-            // A `DereferencedJSONSchema` must not contain references. Dynamic-scope
-            // resolution is not yet implemented (see #359), so a `$dynamicRef`
-            // cannot be inlined; dereferencing fails rather than retaining the
-            // reference and breaking the `Dereferenced...` invariant.
+        case .dynamicReference(let reference, let context):
+            // Resolve `$dynamicRef` against the dynamic scope. Only plain anchor
+            // references participate; component/path/external dynamic refs have no
+            // matching dynamic anchor and throw.
+            if case .internal(.anchor(let anchorName)) = reference.jsonReference,
+               let target = dynamicScope[anchorName] {
+                let cycleKey = AnyHashable("dynamicRef:#\(anchorName)")
+                if references.contains(cycleKey) {
+                    // Recursive dynamic reference: cannot inline without retaining a
+                    // reference, so fail -- consistent with static `$ref` cycles.
+                    throw OpenAPI.Components.ReferenceCycleError(ref: reference.absoluteString)
+                }
+                var newReferences = references
+                newReferences.insert(cycleKey)
+                var dereferenced = try target
+                    ._dereferenced(in: components, following: newReferences, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope)
+
+                if !context.required {
+                    dereferenced = dereferenced.optionalSchemaObject()
+                }
+                if let refDescription = context.description {
+                    dereferenced = dereferenced.with(description: refDescription)
+                }
+
+                var extensions = dereferenced.vendorExtensions
+                if let name {
+                    extensions[OpenAPI.Components.componentNameExtension] = .init(name)
+                }
+                dereferenced = dereferenced.with(vendorExtensions: extensions)
+
+                return dereferenced
+            }
             throw GenericError(
                 subjectName: "JSONSchema",
-                details: "Cannot dereference `$dynamicRef` ('\(reference.absoluteString)'): dynamic references are not resolved by local dereferencing.",
+                details: "Cannot dereference `$dynamicRef` ('\(reference.absoluteString)'): no matching `$dynamicAnchor` found in dynamic scope.",
                 codingPath: []
             )
         case .boolean(let context):
@@ -523,12 +589,12 @@ extension JSONSchema: LocallyDereferenceable {
         case .object(let coreContext, let objectContext):
             return try .object(
                 addComponentNameExtension(to: coreContext),
-                DereferencedJSONSchema.ObjectContext(objectContext, resolvingIn: components, following: references)
+                DereferencedJSONSchema.ObjectContext(objectContext, resolvingIn: components, following: references, dynamicScope: dynamicScope)
             )
         case .array(let coreContext, let arrayContext):
             return try .array(
                 addComponentNameExtension(to: coreContext),
-                DereferencedJSONSchema.ArrayContext(arrayContext, resolvingIn: components, following: references)
+                DereferencedJSONSchema.ArrayContext(arrayContext, resolvingIn: components, following: references, dynamicScope: dynamicScope)
             )
         case .number(let coreContext, let numberContext):
             return .number(addComponentNameExtension(to: coreContext), numberContext)
@@ -537,16 +603,16 @@ extension JSONSchema: LocallyDereferenceable {
         case .string(let coreContext, let stringContext):
             return .string(addComponentNameExtension(to: coreContext), stringContext)
         case .all(of: let jsonSchemas, core: let coreContext):
-            let schemas = try jsonSchemas.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
+            let schemas = try jsonSchemas.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope) }
             return .all(of: schemas, core: addComponentNameExtension(to: coreContext))
         case .one(of: let jsonSchemas, core: let coreContext):
-            let schemas = try jsonSchemas.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
+            let schemas = try jsonSchemas.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope) }
             return .one(of: schemas, core: addComponentNameExtension(to: coreContext))
         case .any(of: let jsonSchemas, core: let coreContext):
-            let schemas = try jsonSchemas.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
+            let schemas = try jsonSchemas.map { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope) }
             return .any(of: schemas, core: addComponentNameExtension(to: coreContext))
         case .not(let jsonSchema, core: let coreContext):
-            return .not(try jsonSchema._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil), core: addComponentNameExtension(to: coreContext))
+            return .not(try jsonSchema._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil, dynamicScope: dynamicScope), core: addComponentNameExtension(to: coreContext))
         case .fragment(let context):
             return .fragment(addComponentNameExtension(to: context))
         }

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaDynamicReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaDynamicReferenceTests.swift
@@ -184,18 +184,76 @@ final class JSONSchemaDynamicReferenceTests: XCTestCase {
         XCTAssertTrue(schema.isDynamicReference)
     }
 
-    // MARK: - Dereferencing
+    // MARK: - Dereferencing (dynamic-scope resolution)
 
-    func test_dereference_throwsOnDynamicReference() throws {
-        // A `DereferencedJSONSchema` must not contain references. Until
-        // dynamic-scope resolution lands (follow-up to #359), a `$dynamicRef`
-        // cannot be inlined, so local dereferencing fails rather than
-        // retaining the reference.
+    func test_dereference_genericsInline() throws {
+        // The JSON Schema "generics" pattern: a `$dynamicAnchor` lives in `$defs`
+        // and the `$dynamicRef` target is a leaf (non-recursive) schema.
+        // Dereferencing inlines the concrete target.
+        let jsonString = """
+        {
+          "$defs": {
+            "itemType": {
+              "$dynamicAnchor": "T",
+              "type": "string"
+            },
+            "other": { "type": "number" }
+          },
+          "type": "object",
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": { "$dynamicRef": "#T" }
+            }
+          }
+        }
+        """
+
+        let box = try orderUnstableDecode(JSONSchema.self, from: jsonString.data(using: .utf8)!)
+        let dereferenced = try box.dereferenced(in: .noComponents)
+
+        guard case .object(_, let objectContext) = dereferenced else {
+            XCTFail("expected .object, got \(dereferenced)")
+            return
+        }
+        let items = try XCTUnwrap(objectContext.properties["items"])
+        let itemsItems: DereferencedJSONSchema = try XCTUnwrap(items.arrayContext?.items)
+
+        // The leaf `$defs.itemType` (`string`) was inlined through the dynamic ref.
+        guard case .string = itemsItems else {
+            XCTFail("expected dynamic ref to inline to .string, got \(itemsItems)")
+            return
+        }
+    }
+
+    func test_dereference_recursiveThrows() throws {
+        // A self-referential schema: `Node` declares `$dynamicAnchor: node` and
+        // its `next` points back at `#node`. Inlining would not terminate, so
+        // dereferencing must throw (consistent with recursive static `$ref`).
+        let jsonString = """
+        {
+          "$dynamicAnchor": "node",
+          "type": "object",
+          "properties": {
+            "value": { "type": "string" },
+            "next": { "$dynamicRef": "#node" }
+          }
+        }
+        """
+
+        let node = try orderUnstableDecode(JSONSchema.self, from: jsonString.data(using: .utf8)!)
+
+        XCTAssertThrowsError(try node.dereferenced(in: .noComponents))
+    }
+
+    func test_dereference_unresolvableThrows() throws {
+        // A `$dynamicRef` whose anchor is not declared anywhere in scope cannot
+        // be resolved and must throw (rather than degrade to `any`/`unknown`).
         let jsonString = """
         {
           "type": "object",
           "properties": {
-            "item": { "$dynamicRef": "#category" }
+            "item": { "$dynamicRef": "#unmatched" }
           }
         }
         """
@@ -205,6 +263,179 @@ final class JSONSchemaDynamicReferenceTests: XCTestCase {
         XCTAssertThrowsError(try schema.dereferenced(in: .noComponents)) { error in
             let description = String(describing: error)
             XCTAssertTrue(description.contains("$dynamicRef"), "expected error to mention `$dynamicRef`, got: \(description)")
+        }
+    }
+
+    func test_dereference_scopePropagatesAcrossRefBoundary() throws {
+        // `Outer` references `Inner`. The dynamic anchor "leaf" lives in `Outer`'s
+        // `$defs`; `Inner` contains the `$dynamicRef`. The dynamic scope must
+        // travel across the `$ref` boundary so Inner's `$dynamicRef` resolves to
+        // Outer's concrete leaf type (outermost anchor wins).
+        let components = OpenAPI.Components(
+            schemas: [
+                "Outer": .reference(
+                    .component(named: "Inner"),
+                    .init(
+                        defs: [
+                            "L": .boolean(.init(dynamicAnchor: "leaf"))
+                        ]
+                    )
+                ),
+                "Inner": .object(
+                    .init(),
+                    .init(properties: [
+                        "flag": .dynamicReference(.anchor("leaf"))
+                    ])
+                )
+            ]
+        )
+
+        let outer = try XCTUnwrap(components.schemas["Outer"])
+        let dereferenced = try outer.dereferenced(in: components)
+
+        // Outer is a reference to Inner, so after dereferencing we see Inner's
+        // object shape with `flag` resolved through the dynamic scope.
+        guard case .object(_, let objectContext) = dereferenced else {
+            XCTFail("expected .object, got \(dereferenced)")
+            return
+        }
+        let flag: DereferencedJSONSchema = try XCTUnwrap(objectContext.properties["flag"])
+
+        // The dynamic ref resolved to Outer's `$defs.L` (.boolean) across the $ref.
+        guard case .boolean = flag else {
+            XCTFail("expected flag to resolve to Outer's `$defs.L` (.boolean) across the $ref, got \(flag)")
+            return
+        }
+    }
+
+    func test_dereference_optionalDescribedDynamicRef() throws {
+        // A `$dynamicRef` that is optional (required: false) and carries a
+        // description: both propagate to the inlined result, mirroring `$ref`.
+        let item = JSONSchema.dynamicReference(.anchor("T"), required: false, description: "the item")
+        let box = JSONSchema.object(
+            .init(defs: ["T": .string(.init(dynamicAnchor: "T"), .init())]),
+            .init(properties: ["item": item])
+        )
+
+        let dereferenced = try box.dereferenced(in: .noComponents)
+
+        guard case .object(_, let objectContext) = dereferenced else {
+            XCTFail("expected .object, got \(dereferenced)")
+            return
+        }
+        let resolved = try XCTUnwrap(objectContext.properties["item"])
+
+        // Inlined to the leaf `.string`, with optionality and description preserved.
+        guard case .string = resolved else {
+            XCTFail("expected dynamic ref to inline to .string, got \(resolved)")
+            return
+        }
+        XCTAssertFalse(resolved.required)
+        XCTAssertEqual(resolved.description, "the item")
+    }
+
+    func test_dereference_nonAnchorDynamicRefThrows() throws {
+        // A `$dynamicRef` whose target is a component path (not a plain anchor)
+        // is not resolved via a dynamic anchor and throws.
+        let jsonString = """
+        {
+          "type": "object",
+          "properties": {
+            "item": { "$dynamicRef": "#/components/schemas/Foo" }
+          }
+        }
+        """
+
+        let schema = try orderUnstableDecode(JSONSchema.self, from: jsonString.data(using: .utf8)!)
+
+        XCTAssertThrowsError(try schema.dereferenced(in: .noComponents))
+    }
+
+    func test_dereference_siblingDynamicRefsResolveIndependently() throws {
+        // Two sibling properties each holding `$dynamicRef "#T"` resolve
+        // independently -- the cycle guard inserted for one must not leak to
+        // the other (both inline to the same leaf type).
+        let jsonString = """
+        {
+          "$defs": { "T": { "$dynamicAnchor": "T", "type": "string" } },
+          "type": "object",
+          "properties": {
+            "a": { "$dynamicRef": "#T" },
+            "b": { "$dynamicRef": "#T" }
+          }
+        }
+        """
+
+        let schema = try orderUnstableDecode(JSONSchema.self, from: jsonString.data(using: .utf8)!)
+        let dereferenced = try schema.dereferenced(in: .noComponents)
+
+        guard case .object(_, let objectContext) = dereferenced else {
+            XCTFail("expected .object, got \(dereferenced)")
+            return
+        }
+        for key in ["a", "b"] {
+            let resolved: DereferencedJSONSchema = try XCTUnwrap(objectContext.properties[key])
+            guard case .string = resolved else {
+                XCTFail("expected sibling `\(key)` to inline to .string, got \(resolved)")
+                return
+            }
+        }
+    }
+
+    func test_dereference_optionalReferenceProperty() throws {
+        // Covers the `.reference` optional (required: false) path threaded by
+        // the scope-aware dereferencer: an optional `$ref` property dereferences
+        // to an optional result.
+        let components = OpenAPI.Components(schemas: [
+            "Foo": .string,
+            "Holder": .object(
+                .init(),
+                .init(properties: [
+                    "opt": .reference(.component(named: "Foo"), .init(required: false))
+                ])
+            )
+        ])
+
+        let holder = try XCTUnwrap(components.schemas["Holder"])
+        let dereferenced = try holder.dereferenced(in: components)
+
+        guard case .object(_, let objectContext) = dereferenced else {
+            XCTFail("expected .object, got \(dereferenced)")
+            return
+        }
+        let opt: DereferencedJSONSchema = try XCTUnwrap(objectContext.properties["opt"])
+        XCTAssertFalse(opt.required)
+    }
+
+    func test_dereference_dynamicRefReachedViaRef() throws {
+        // A `$ref` to a component that is itself a `$dynamicRef`: the component
+        // name propagates (dereferencedFromComponentNamed) and the dynamicRef
+        // resolves against the referencing schema's dynamic scope.
+        let components = OpenAPI.Components(
+            schemas: [
+                "Wrapper": .object(
+                    .init(defs: ["T": .string(.init(dynamicAnchor: "T"), .init())]),
+                    .init(properties: [
+                        "item": .reference(.component(named: "DynRef"))
+                    ])
+                ),
+                "DynRef": .dynamicReference(.anchor("T"))
+            ]
+        )
+
+        let wrapper = try XCTUnwrap(components.schemas["Wrapper"])
+        let dereferenced = try wrapper.dereferenced(in: components)
+
+        guard case .object(_, let objectContext) = dereferenced else {
+            XCTFail("expected .object, got \(dereferenced)")
+            return
+        }
+        let item: DereferencedJSONSchema = try XCTUnwrap(objectContext.properties["item"])
+
+        // $ref DynRef -> DynRef is $dynamicRef #T -> resolves to Wrapper's $defs.T (.string).
+        guard case .string = item else {
+            XCTFail("expected item to resolve to .string via $ref -> $dynamicRef, got \(item)")
+            return
         }
     }
 }

--- a/documentation/migration_guides/v7_migration_guide.md
+++ b/documentation/migration_guides/v7_migration_guide.md
@@ -17,14 +17,10 @@ encodes/decodes the `$dynamicRef` keyword. Schemas whose only attribute is
 `$dynamicRef` now decode as `.dynamicReference` instead of decoding as an empty
 `.fragment` with an "unsupported attributes" warning.
 
-### Local dereferencing resolves `$dynamicRef` against the dynamic scope
+### Local dereferencing resolves `$dynamicRef`
 
 `locallyDereferenced()` and `JSONSchema.dereferenced(in:)` now resolve
-`$dynamicRef` against the dynamic scope (the outermost in-scope `$dynamicAnchor`
-wins, per JSON Schema 2020-12). Non-recursive targets are inlined. Recursive
-or unresolvable `$dynamicRef`s **throw** — a `DereferencedJSONSchema` must not
-contain references, so a dynamic ref that cannot be fully inlined fails the
-same way a recursive static `$ref` does (`ReferenceCycleError`).
+`$dynamicRef` against the dynamic scope.
 
 ### `$ref` with a plain fragment now round-trips verbatim
 
@@ -34,5 +30,4 @@ rather than `.path(...)`. The practical effect is that such references round-tri
 verbatim (`"#foo"`) instead of being rewritten with a slash (`"#/foo"`).
 References into the Components Object (`#/components/...`) and JSON-pointer paths
 (`#/foo/bar`) are unaffected.
-
 

--- a/documentation/migration_guides/v7_migration_guide.md
+++ b/documentation/migration_guides/v7_migration_guide.md
@@ -17,14 +17,14 @@ encodes/decodes the `$dynamicRef` keyword. Schemas whose only attribute is
 `$dynamicRef` now decode as `.dynamicReference` instead of decoding as an empty
 `.fragment` with an "unsupported attributes" warning.
 
-### Local dereferencing fails on `$dynamicRef`
+### Local dereferencing resolves `$dynamicRef` against the dynamic scope
 
-A `DereferencedJSONSchema` must not contain references. Until dynamic-scope
-resolution is added (tracked in #359), `locallyDereferenced()` and
-`JSONSchema.dereferenced(in:)` **throw** when they encounter a `$dynamicRef`
-they cannot inline, mirroring how unresolvable static `$ref` values fail. The
-raw `JSONSchema` AST still carries `.dynamicReference` for tools that read
-schemas without dereferencing.
+`locallyDereferenced()` and `JSONSchema.dereferenced(in:)` now resolve
+`$dynamicRef` against the dynamic scope (the outermost in-scope `$dynamicAnchor`
+wins, per JSON Schema 2020-12). Non-recursive targets are inlined. Recursive
+or unresolvable `$dynamicRef`s **throw** — a `DereferencedJSONSchema` must not
+contain references, so a dynamic ref that cannot be fully inlined fails the
+same way a recursive static `$ref` does (`ReferenceCycleError`).
 
 ### `$ref` with a plain fragment now round-trips verbatim
 


### PR DESCRIPTION
Part of #359.

Implements the "dynamic-scope-aware dereferencing" item from the #359 task list. `locallyDereferenced()` / `JSONSchema.dereferenced(in:)` now resolve `$dynamicRef` against the dynamic scope (the outermost in-scope `$dynamicAnchor` wins, per JSON Schema 2020-12 §7.7), instead of throwing on every `$dynamicRef`.

## Behavior

- **Non-recursive `$dynamicRef`** (e.g. the JSON Schema "generics" pattern — `$dynamicRef "#T"` → a leaf `$defs` entry): the target is inlined.
- **Recursive or unresolvable `$dynamicRef`**: **throws** (`ReferenceCycleError` / `GenericError`), consistent with how recursive static `$ref` already fails and with the `Dereferenced...` invariant that a `DereferencedJSONSchema` contains no references.
- The dynamic scope is reconstructed from the document's static structure: seeded from each schema's own `$dynamicAnchor` (and `$defs`-declared anchors, first-wins/outermost-wins) and threaded through subschemas and across `$ref` boundaries.

## Notes

- Raw-AST consumers (most generators, e.g. `swift-openapi-generator`) are unaffected — `.dynamicReference` on `JSONSchema` is unchanged; only `locallyDereferenced()` behavior changes (strictly an improvement: previously it threw on *all* `$dynamicRef`; now only recursive/unresolvable ones).
- Edits the same migration-guide section as #503 (external deref); trivial doc reconcile on merge.

## Testing

- New deref tests: generics-inline, recursive-throws, unresolvable-throws, non-anchor-throws, optional+described propagation, sibling dynamic-ref independence, scope-propagates-across-`$ref`, `$ref`→`$dynamicRef` name propagation, optional `$ref` property.
- Full suite: **2165 tests, 0 failures** (2157 prior + 8 new; no regressions — the `.reference` refactor is behavior-preserving).
- **100% region coverage** on the new code (`llvm-cov`-verified: 0 uncovered regions in the scope-aware `_dereferenced` + the `ArrayContext`/`ObjectContext` threading).

---
*This PR was drafted with assistance from AI tooling. The submitter has reviewed and validated the contents prior to submission.*